### PR TITLE
Fixed typo in initialization procedure

### DIFF
--- a/firmware/src/sdcard.cpp
+++ b/firmware/src/sdcard.cpp
@@ -206,7 +206,7 @@ bool sdcard_card_init()
 
   // Initialize card
   debug_printP(PSTR("CMD55&ACMD41\n\r"));
-  if (!(sdcard_wait_for_astatus(SD_AMCD_SD_SEND_OP_COND, type == SD_SD2 ? 0x40000000 : 0, R1_IDLE, 200)))
+  if (!(sdcard_wait_for_astatus(SD_AMCD_SD_SEND_OP_COND, type == SD_SD2 ? 0x40000000 : 0, 0x00, 200)))
     goto failure;
 
   // Check for SDHC


### PR DESCRIPTION
After acmd 41, must wait for empty R1 (0x00), not IDLE (0x01).

Solves #2 