### PR TITLE
Fixes wrong SD block addressing when FAT's sectors per cluster is not 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The following table resumes the available commands.
 | `LST`   | none       | List files and directory in the current working directory                       |
 | `SET`   | `filename` | Select `filename`, in current working directory, as currently inserted disk (2) |
 | `REM`   | none       | Remove currently inserted disk                                                  |
+| `FAT`   | `upto`     | Prints FAT entries of selected file up to index `upto` (debug)                  |
+| `INFO`  | `t` `s`    | Prints .NIC file informations about sector `s` in track `t` (debug)             |
 
 1. If OLED is not connected, the SD Card must be manually initialized.
 2. At startup, no disk is inserted.
@@ -101,4 +103,5 @@ The following table resumes the available commands.
 
 ## Contributors and references
 
-The whole projects borns as a custom implementation of Koichi Nishida's SdiskII [[1]](https://tulip-house.ddo.jp/digital/SDISK2/english.html) [[2]](https://github.com/suaide/SDisk2), which I used as a starting point for firmware developement.
+* The whole projects borns as a custom implementation of Koichi Nishida's SdiskII [[1]](https://tulip-house.ddo.jp/digital/SDISK2/english.html) [[2]](https://github.com/suaide/SDisk2), which I used as a starting point for firmware developement.
+* Jörg Hagedorn made a replica of the tinyDiskII hardware rev1.1 and he found a bug in the SD sector's addressing, now fixed.

--- a/firmware/src/prompt.cpp
+++ b/firmware/src/prompt.cpp
@@ -77,7 +77,7 @@ static const prompt_commands_t prompt_commands[] = {
   {"REM", do_rem},
   {"INIT", do_init},
   // Debug commands
-  {"FAT", do_fat}, // Print FAT table for a selected file. No arguments
+  {"FAT", do_fat}, // Print FAT table for a selected file up to n-th entry
   {"INFO", do_info}, // Dump sector info for given sector and track passed as argument
   {NULL, NULL}
 };

--- a/firmware/src/prompt.cpp
+++ b/firmware/src/prompt.cpp
@@ -58,6 +58,9 @@ static void do_set(const char *arg, size_t len);
 static void do_rem(const char *arg, size_t len);
 static void do_init(const char *arg, size_t len);
 
+static void do_fat(const char *arg, size_t len);
+static void do_info(const char *arg, size_t len);
+
 /* * * * * * * * * * * * * * *  STATIC VARIABLES  * * * * * * * * * * * * * * */
 
 // Buffers for received data
@@ -73,6 +76,9 @@ static const prompt_commands_t prompt_commands[] = {
   {"SET", do_set},
   {"REM", do_rem},
   {"INIT", do_init},
+  // Debug commands
+  {"FAT", do_fat}, // Print FAT table for a selected file. No arguments
+  {"INFO", do_info}, // Dump sector info for given sector and track passed as argument
   {NULL, NULL}
 };
 
@@ -166,6 +172,37 @@ static void do_init(const char *arg __attribute__((unused)), size_t len __attrib
 #endif
     debug_printP(PSTR("Failed initialization\n\r"));
   }
+}
+
+static void do_fat(const char *arg __attribute__((unused)), size_t len __attribute__((unused))) {
+  if (!nic_file_selected()) {
+    debug_printP(PSTR("No file selected\n\r"));
+    return;
+  }
+
+  uint16_t upto = 0;
+
+  if (len > 0)
+    upto = strtol(arg, NULL, 10);
+
+  debug_dump_fat(upto);
+}
+
+static void do_info(const char *arg, size_t) {
+  if (!nic_file_selected()) {
+    debug_printP(PSTR("No file selected\n\r"));
+    return;
+  }
+
+  char *ptr;
+  if (*arg == '\0')
+    return;
+  uint8_t track = strtol(arg, &ptr, 10);
+  if (*ptr == '\0')
+    return;
+  uint8_t sector = strtol(ptr, &ptr, 10);
+
+  debug_dump_sect_info(track, sector);
 }
 
 /* * * * * * * * * * * * * * *  GLOBAL FUNCTIONS  * * * * * * * * * * * * * * */

--- a/firmware/src/sdcard_nic.cpp
+++ b/firmware/src/sdcard_nic.cpp
@@ -78,8 +78,9 @@ bool nic_update_sector(uint8_t dsk_trk, uint8_t dsk_sector)
   uint16_t dsk_index = (uint16_t)dsk_trk * 16 + dsk_sector;
   // Get current SD cluster index to find its address in FAT
   uint8_t sd_cluster = dsk_index >> sectors_per_cluster2;
-  // Bytes per sector is assumed to be 512
-  uint16_t sd_sector_offset = dsk_index % 4;
+  // Compute the .nic sector offset within a FAT cluster
+  uint16_t mask = (1 << sectors_per_cluster2) - 1;
+  uint16_t sd_sector_offset = dsk_index & mask;
 
   // Check if FAT entry is valid
   if (nic_fat[sd_cluster] < 2)
@@ -128,11 +129,12 @@ bool nic_write_sector(uint8_t *buffer, uint8_t volume, uint8_t track, uint8_t se
   uint8_t c;
 
   // Compute current sector index (0..16*35) FIXME
-  uint16_t dsk_sector = (uint16_t)track * 16 + sector;
+  uint16_t dsk_index = (uint16_t)track * 16 + sector;
   // Get current SD cluster index to find its address in FAT
-  uint8_t sd_cluster = dsk_sector >> sectors_per_cluster2;
-  // Bytes per sector is assumed to be 512
-  uint16_t sd_sector_offset = dsk_sector % 4;
+  uint8_t sd_cluster = dsk_index >> sectors_per_cluster2;
+  // Compute the .nic sector offset within a FAT cluster
+  uint16_t mask = (1 << sectors_per_cluster2) - 1;
+  uint16_t sd_sector_offset = dsk_index & mask;
 
   // Get cluster from reordered FAT table and convert in sectors
   uint32_t sd_address = nic_fat[sd_cluster] - 2;
@@ -229,8 +231,9 @@ void debug_dump_sect_info(uint8_t track, uint8_t sector) {
   uint16_t dsk_index = (uint16_t)track * 16 + sector;
   // Get current SD cluster index to find its address in FAT
   uint8_t sd_cluster = dsk_index >> sectors_per_cluster2;
-  // Bytes per sector is assumed to be 512
-  uint16_t sd_sector_offset = dsk_index % 4;
+  // Compute the .nic sector offset within a FAT cluster
+  uint16_t mask = (1 << sectors_per_cluster2) - 1;
+  uint16_t sd_sector_offset = dsk_index & mask;
 
   debug_printP(PSTR("dsk_index: %x\n\r"), dsk_index);
   debug_printP(PSTR("sd_cluster: %x\n\r"), sd_cluster);

--- a/firmware/src/sdcard_nic.h
+++ b/firmware/src/sdcard_nic.h
@@ -24,4 +24,7 @@ uint8_t nic_get_bit();
 void nic_abort_read(uint16_t bits);
 bool nic_write_sector(uint8_t *buffer, uint8_t volume, uint8_t track, uint8_t sector);
 
+void debug_dump_fat(uint16_t upto);
+void debug_dump_sect_info(uint8_t track, uint8_t sector);
+
 #endif // SRC_SDCARD_NIC_H_


### PR DESCRIPTION
Closes #5.

- [x] First commit is for local debug only, must be removed.
- [x] To be cleaned: debug routines can be kept but further documentation is needed (#6).
